### PR TITLE
feat(roguelike_tag): color multiple labels

### DIFF
--- a/dist/roguelike_tag.user.js
+++ b/dist/roguelike_tag.user.js
@@ -115,6 +115,7 @@
                 border: 1px solid #cecdce;
             }
 
+            td.gall_writer.ub-writer { text-align: left; }
             td.gall_tit.ub-word {
                 & {
                     display: flex;

--- a/dist/roguelike_tag.user.js
+++ b/dist/roguelike_tag.user.js
@@ -204,11 +204,13 @@
 			})
 			.forEach(({ el, tags }) => {
 				const labels = tags.map((key) => /*html*/ `<span ${attr(key)}>${key}</span>`)
+				const em = el.querySelector("em")?.cloneNode()
 
 				el.innerHTML = /*html*/ `
                     ${labels.join("")}
                     ${el.innerText.replace(tagsRe, "")}
                 `
+				if (em) el.prepend(em)
 			})
 
 	const tbody = document.querySelector("tbody")

--- a/dist/roguelike_tag.user.js
+++ b/dist/roguelike_tag.user.js
@@ -218,7 +218,9 @@
 		const evilJquerySearchTrigger = document.querySelector("input[name=s_keyword]")
 		if (evilJquerySearchTrigger) evilJquerySearchTrigger.value = ""
 
+		const now = performance.now()
 		tag()
+		console.log(`adding tags took ${Math.round(performance.now() - now)}ms`)
 
 		const observer = new MutationObserver(tag)
 


### PR DESCRIPTION
## Summary

| PC | Mobile |
|--------|--------|
| ![image](https://github.com/scarf005/userscript/assets/54838975/2f0e6e63-3c9d-4a9c-a63f-9779723834b7) | ![image](https://github.com/scarf005/userscript/assets/54838975/8ba1d1d0-029f-4c75-a52b-62ec7147c5fb) |

automatically color multiple labels

## Description

- regex condition is more unforgiving to parse `tag1,tag2,...tagN) title`
- hash title to RGB
